### PR TITLE
make library compatible to windows

### DIFF
--- a/src/evengsdk/api.py
+++ b/src/evengsdk/api.py
@@ -172,7 +172,7 @@ class EvengApi:
         quoted_parts = [str(quote_plus(x)) for x in path.parts[1:]]
 
         # rejoin the path and return string
-        new_path = Path("/").joinpath(*quoted_parts)
+        new_path = Path("/").joinpath(*quoted_parts).as_posix()
         return str(new_path)
 
     def get_lab(self, path: str):


### PR DESCRIPTION
The `Path` class does use OS-dependent directory separators, so `mylab.unl` becomes `\mylab.unl` on Windows and results in an error, e.g. when using the `/lab/<lab-filename>` endpoint.
Using `.as_posix()` forces `/` as a separator and fixes that issue.