### PR TITLE
Issue109-wipe-exported-configs-on-delete

### DIFF
--- a/src/evengsdk/api.py
+++ b/src/evengsdk/api.py
@@ -758,6 +758,11 @@ class EvengApi:
         url = "/labs" + f"{self.normalize_path(path)}"
         return self.client.put(url, data=json.dumps(param))
 
+    def close_lab(self) -> Dict:
+        """Close the current lab."""
+        url = "/labs/close"
+        return self.client.delete(url)
+
     def delete_lab(self, path: str) -> Dict:
         """Delete an existing lab
 

--- a/src/evengsdk/cli/lab/commands.py
+++ b/src/evengsdk/cli/lab/commands.py
@@ -443,8 +443,18 @@ def delete(ctx, path):
         eve-ng lab delete --path /lab1
     """
     client = get_client(ctx)
-    response = client.api.delete_lab(path)
-    cli_print_output("text", response)
+    with console.status("[bold green]wiping nodes...") as status:
+        # wipe nodes
+        resp1 = client.api.wipe_all_nodes(path)
+        console.log(f"{resp1['status']}: {resp1['message']}")
+        # stop all nodes
+        status.update("[bold green]closing lab...")
+        resp2 = client.api.close_lab()
+        console.log(f"{resp2['status']}: {resp2['message']}")
+        # delete the lab
+        status.update("[bold green]deleting lab...")
+        response = client.api.delete_lab(path)
+        cli_print_output("text", response)
 
 
 @click.command()


### PR DESCRIPTION
* wipe nodes and close lab before delete - fixes #109
* add `.close_lab` to api wrapper - closes #110