### PR TITLE
handle error for topology in empty lab

### DIFF
--- a/src/evengsdk/cli/lab/commands.py
+++ b/src/evengsdk/cli/lab/commands.py
@@ -229,6 +229,10 @@ def topology(ctx, path, output):
     """
     client = get_client(ctx)
     resp = client.api.get_lab_topology(path)
+
+    if not resp.get("data"):
+        cli_print_error("No Topology information available. Is the lab empty?")
+
     table_header = [
         ("type", {}),
         ("source", dict(justify="center", style="cyan", no_wrap=True)),

--- a/src/tests/cli/test_cli_lab.py
+++ b/src/tests/cli/test_cli_lab.py
@@ -108,15 +108,15 @@ class TestLabCommands:
         result = self._run_commands(["lab", "list"])
         assert result.exit_code == 0, result.output
 
-    @pytest.mark.skip(reason="TODO: fix empty lab raises error")
-    def test_list_lab_topology(self):
+    def test_list_lab_empty_topology(self, cli_lab_path):
         """
         Arrange/Act: Run the `lab` command with the 'topology' subcommand.
         Assert: The output indicates that lab topology is retrieved
             successfully.
         """
-        result = self._run_commands(["lab", "topology"])
-        assert result.exit_code == 0, result.output
+        result = self._run_commands(["lab", "topology"], cli_lab_path)
+        assert result.exit_code > 0
+        assert "no topology" in result.output.lower()
 
 
 @pytest.mark.usefixtures("setup_cli_lab")


### PR DESCRIPTION
* Add error handling for `lab topology` command when there are no lab nodes 